### PR TITLE
Ok json

### DIFF
--- a/lib/push/heroku/cisaurus/cisaurus.rb
+++ b/lib/push/heroku/cisaurus/cisaurus.rb
@@ -1,6 +1,6 @@
 class Cisaurus
 
-  CISAURUS_CLIENT_VERSION = "0.7-ALPHA"
+  CISAURUS_CLIENT_VERSION = "0.8-ALPHA"
   CISAURUS_HOST = ENV['CISAURUS_HOST'] || "cisaurus.heroku.com"
 
   def initialize(api_key, host = CISAURUS_HOST, api_version = "v1")


### PR DESCRIPTION
This is a change to make the client Ruby 1.8.7-compatible. Replacing 1.9.3-dependent JSON lib with OK-JSON.
