### PR TITLE
Fix for windows paths

### DIFF
--- a/vendor/anvil/lib/anvil/manifest.rb
+++ b/vendor/anvil/lib/anvil/manifest.rb
@@ -167,7 +167,7 @@ private
       next if %w( . .. ).include?(File.basename(path))
       next if File.pipe?(path)
       next if path =~ /\.swp$/
-      next unless path =~ /^[A-Za-z0-9\-\_\.\/]*$/
+      next unless path =~ /^[A-Za-z0-9\-\_\.\/\:]*$/
       manifest[relative] = file_manifest(path)
     end
     manifest


### PR DESCRIPTION
Fix for https://github.com/ddollar/heroku-push/issues/3

``` ruby
path =~ /^[A-Za-z0-9\-\_\.\/]*$/
```

won't match windows paths like `C:\Users\user\dir` even if ruby sees them as `C:/Users/user/dir`
