### PR TITLE
Allow to override release description via ENV

### DIFF
--- a/lib/push/heroku/command/push.rb
+++ b/lib/push/heroku/command/push.rb
@@ -42,7 +42,7 @@ class Heroku::Command::Push < Heroku::Command::Base
 
     action("Releasing to #{app}") do
       cisaurus = Cisaurus.new(Heroku::Auth.password)
-      release = cisaurus.release(app, "Pushed by #{user}", slug_url) {
+      release = cisaurus.release(app, ENV["HEROKU_RELEASE_DESC"] || "Pushed by #{user}", slug_url) {
         print "."
         $stdout.flush
       }


### PR DESCRIPTION
Now you can use HEROKU_RELEASE_DESC=${git rev-parse HEAD} or others to specify a description in a new release

My particular use case is that we're using heroku push from our Mercurial repository, so it'd be nice to have the revision in the description. With this change, everybody can now supply a custom description for the releases...